### PR TITLE
resume feature added

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
 
       - name: Install Dependencies
         run: pip install -r dev-requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Src specific
+.state.block
+.state.pickle

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ boto3==1.26.41
 moto==4.0.12
 mypy==1.1.1
 pytest==7.2.0
+rehash==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3-stubs[s3]
 boto3==1.26.41
+rehash==1.0.1

--- a/src/resume.py
+++ b/src/resume.py
@@ -1,0 +1,32 @@
+"""
+This module is responsible for loading the state of the hashing process.
+"""
+import pickle
+from typing import Tuple
+from src.logger import logger
+import rehash
+
+
+def load_state() -> Tuple[int, rehash.ResumableHasher]:
+    '''try and load existing state'''
+    try:
+        with open('.state.block', 'r',  encoding='utf-8') as previous_block_number, \
+                open('.state.pickle', 'rb') as previous_hash:
+
+            hash_object = pickle.load(previous_hash)
+            start_block = int(previous_block_number.read()) + 1
+            return start_block, hash_object
+    except FileNotFoundError:
+        return 0, rehash.new('md5')
+
+
+def save_state(block_number: int, hash_object: rehash.ResumableHasher) -> None:
+    '''try and save state'''
+    try:
+        with open('.state.block', 'w',  encoding='utf-8') as current_block_number, \
+                open('.state.pickle', 'wb') as current_hash:
+            pickle.dump(hash_object, current_hash)
+            current_block_number.write(str(block_number))
+
+    except OSError as exception:
+        raise OSError('Could not save state') from exception

--- a/src/s3_md5.py
+++ b/src/s3_md5.py
@@ -1,11 +1,12 @@
 '''module uses threads to download file from s3 and generates md5 hash'''
 from concurrent.futures import ThreadPoolExecutor
-from hashlib import md5
+from os import remove
 
 from mypy_boto3_s3 import S3Client
 
 from src.logger import logger
 from src.s3_file import S3FileHelper
+from src.resume import load_state, save_state
 
 
 def parse_file_md5(s3_client: S3Client,
@@ -20,23 +21,45 @@ def parse_file_md5(s3_client: S3Client,
     if file_size < chunk_size:
         raise AssertionError('file size cannot be smaller than chunk size')
     logger.info(f'file size {file_size} bytes')
-    file_chunk_count = file_size // chunk_size
-    logger.info(f'file chunk count {file_chunk_count}')
 
-    with ThreadPoolExecutor(max_workers=workers) as thread_executor:
-        def wrapper(part_number: int):
-            ranged_bytes_string = s3_file.calculate_range_bytes_from_part_number(
-                part_number, chunk_size, file_chunk_count)
-            logger.info(f"downloading {ranged_bytes_string}")
-            ranged_bytes = s3_file.get_range_bytes(ranged_bytes_string)
-            logger.info(f"downloaded {ranged_bytes_string}")
-            return ranged_bytes
+    chunk_count = file_size // chunk_size
+    logger.info(f'chunk count {chunk_count}')
 
-        logger.info('downloading file')
-        results = thread_executor.map(wrapper,
-                                      range(file_chunk_count))
+    if chunk_count < workers:
+        raise AssertionError('chunk size too large')
 
-        hash_object = md5()
-        for result in results:
-            hash_object.update(result)
-        return hash_object.hexdigest()
+    block_count = chunk_count // workers
+    logger.info(f'block count {block_count}')
+
+    chunk_count_per_block = chunk_count // block_count
+    logger.info(f'chunk to get per block {chunk_count_per_block}')
+
+    start_block, hash_object = load_state()
+    if start_block != 0:
+        logger.info(f"resuming from block {start_block}")
+
+    for block_number in range(start_block, block_count):
+        logger.info(f"processing block {block_number}")
+        start_part_number = block_number * chunk_count_per_block
+        end_part_number = chunk_count - 1 if block_number == block_count - \
+            1 else (start_part_number + chunk_count_per_block) - 1
+        logger.info(f"part number {start_part_number}-{end_part_number}")
+
+        with ThreadPoolExecutor(max_workers=workers) as thread_executor:
+            def wrapper(part_number: int):
+                ranged_bytes_string = s3_file.calculate_range_bytes_from_part_number(
+                    part_number, chunk_size, chunk_count)
+                logger.debug(f"downloading {ranged_bytes_string}")
+                ranged_bytes = s3_file.get_range_bytes(ranged_bytes_string)
+                logger.debug(f"downloaded {ranged_bytes_string}")
+                return ranged_bytes
+
+            for result in thread_executor.map(wrapper,
+                                              range(start_part_number, end_part_number + 1)):
+                hash_object.update(result)
+            save_state(block_number, hash_object)
+
+    remove('.state.block')
+    remove('.state.pickle')
+
+    return hash_object.hexdigest()

--- a/test/test_parse_file_md5.py
+++ b/test/test_parse_file_md5.py
@@ -7,7 +7,7 @@ from mypy_boto3_s3 import S3Client
 from src.s3_md5 import parse_file_md5
 
 
-def test_get_md5_hash(s3_setup: Tuple[S3Client, str, str, str]):
+def test_parse_file_md5(s3_setup: Tuple[S3Client, str, str, str]):
     '''test function'''
     s3_client, test_bucket, test_file_name, test_body = s3_setup
     md5_hash = parse_file_md5(s3_client, test_bucket, test_file_name, 1, 1)

--- a/test/test_resumed_parse_file_md5.py
+++ b/test/test_resumed_parse_file_md5.py
@@ -1,0 +1,26 @@
+'''tests the driver function'''
+from hashlib import md5
+from pickle import dump
+from typing import Tuple
+
+from mypy_boto3_s3 import S3Client
+from rehash import new
+
+from src.s3_md5 import parse_file_md5
+
+
+def test_resumed_parse_file_md5(s3_setup: Tuple[S3Client, str, str, str]):
+    '''test function'''
+    s3_client, test_bucket, test_file_name, test_body = s3_setup
+
+    with open('.state.block', 'w', encoding="utf-8") as previous_block_number:
+        previous_block_number.write('1')
+
+    hash_object = new('md5')
+    hash_object.update(bytes(test_body[0:2], 'utf-8'))
+
+    with open('.state.pickle', 'wb') as previous_md5_hash:
+        dump(hash_object, previous_md5_hash)
+
+    md5_hash = parse_file_md5(s3_client, test_bucket, test_file_name, 1, 1)
+    assert md5_hash == md5(bytes(test_body, 'utf-8')).hexdigest()


### PR DESCRIPTION
Uses pickle and rehash to resume hash if earlier attempts have failed.
This comes with its own set of caveats. The rehash library does not support openSSL 3.x which is the current version.